### PR TITLE
Remove GOPATH export in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,6 @@ DOCKER_REPO_ROOT="/go/src/$(PROJECT)"
 
 GIT_SHA=$(shell git rev-parse --short HEAD || echo GitNotFound)
 export KUBECONFIG=$(HOME)/.kube/config
-export GOPATH=$(HOME)/go
 export GREP=grep --color=never
 
 PKGS=$(shell go list ./cmd/... ./pkg/... | grep -v -e generated -e apis/clusterlabs/v1alpha1)


### PR DESCRIPTION
Fixes #1
Makefile assumes and exports GOPATH. It fails build in environments with custom GOPATH.
It will be better to treat GOPATH as dependency set through an environment variable.